### PR TITLE
Fixing module import error

### DIFF
--- a/munin/i2c_pressure
+++ b/munin/i2c_pressure
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8
 
-from Adafruit_BMP085 import BMP085
+import Adafruit_BMP.BMP085 as BMP085
 import sys
 
 # ===========================================================================
@@ -10,7 +10,7 @@ import sys
 
 # Initialise the BMP085 and use STANDARD mode (default value)
 # bmp = BMP085(0x77, debug=True)
-bmp = BMP085(0x77)
+bmp = BMP085.BMP085()
 
 # To specify a different operating mode, uncomment one of the following:
 # bmp = BMP085(0x77, 0)  # ULTRALOWPOWER Mode
@@ -18,10 +18,10 @@ bmp = BMP085(0x77)
 # bmp = BMP085(0x77, 2)  # HIRES Mode
 # bmp = BMP085(0x77, 3)  # ULTRAHIRES Mode
 
-temp = bmp.readTemperature()
+temp = bmp.read_temperature()
 
 # Read the current barometric pressure level
-pressure = bmp.readPressure()
+pressure = bmp.read_pressure()
 
 is_config = len(sys.argv) == 2 and sys.argv[1] == "config"
 

--- a/munin/i2c_temperature
+++ b/munin/i2c_temperature
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8
 
-from Adafruit_BMP085 import BMP085
+import Adafruit_BMP.BMP085 as BMP085
 import sys
 
 # ===========================================================================
@@ -10,7 +10,7 @@ import sys
 
 # Initialise the BMP085 and use STANDARD mode (default value)
 # bmp = BMP085(0x77, debug=True)
-bmp = BMP085(0x77)
+bmp = BMP085.BMP085()
 
 # To specify a different operating mode, uncomment one of the following:
 # bmp = BMP085(0x77, 0)  # ULTRALOWPOWER Mode
@@ -18,10 +18,10 @@ bmp = BMP085(0x77)
 # bmp = BMP085(0x77, 2)  # HIRES Mode
 # bmp = BMP085(0x77, 3)  # ULTRAHIRES Mode
 
-temp = bmp.readTemperature()
+temp = bmp.read_temperature()
 
 # Read the current barometric pressure level
-pressure = bmp.readPressure()
+pressure = bmp.read_pressure()
 
 is_config = len(sys.argv) == 2 and sys.argv[1] == "config"
 


### PR DESCRIPTION
This fixes #10 where munin plugins give the error:

**ImportError: No module named Adafruit_BMP085**

I am no python expert so I am not sure why it does not work since the original commit by @allo-  is only 6 months old. Maybe we need info on his setup?

My setup:

Raspberry pi 2, Ubuntu 14.04, python 2.7
